### PR TITLE
feat: implement NumbFS user-space utilities suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,93 @@
-# NumbFS-utils: The userspace toolset for NumbFS
+![NumbFS-utils](https://img.shields.io/badge/Project-NumbFS-green)
+[![License: GPL-2.0-only](https://img.shields.io/badge/License-GPL%202.0--only-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+
+# NumbFS-utils
+User-space utilities for the NumbFS filesystem.
+
+## Overview
+NumbFS-utils provides essential tools to create, manage, and inspect disk images for the **NumbFS** filesystem. It includes:
+
+- `mkfs.numbfs`: Formats a block device or file as a NumbFS partition.
+- `fsck.numbfs`: Print file system information.
+
+## Prerequisites
+Build tools:
+```bash
+# Debian/Ubuntu
+sudo apt install meson (>=0.50) ninja-build
+# Fedora
+sudo dnf install meson ninja-build
+```
+## Installation
+1. Clone the repository:
+```bash
+https://github.com/salvete/NumbFS-utils.git
+cd NumbFS-utils
+```
+
+2. Build and install:
+```bash
+meson setup build  # or meson setup build -Dnumbfs_debug=true
+ninja -C build
+sudo ninja -C build install  # Installs to /usr/local/bin by default
+```
+
+## Usage
+### 1. Create a filesystem image
+```bash
+mkfs.numbfs /path/to/device_or_image_file
+```
+Example:
+```bash
+mkfs.numbfs disk.img  # Creates a NumbFS image on regular file
+
+or
+
+mfks.numbfs /dev/vdc # Creates a NumbFS image on bloce device
+```
+
+### 2. Check an image
+```bash
+fsck.numbfs /path/to/image
+```
+Example:
+```bash
+# testfile is a 10MB NumbFS filesystem image with root inode ID 1
+$ fsck.numbfs --inodes --blocks --nid 1 ./testfile
+
+Superblock Information
+    inode bitmap start:         2
+    inode zone start:           3
+    block bitmap start:         515
+    data zone start:            520
+    total inodes:               4096
+    total free data blocks:     19959
+    inodes usage:               0.00%
+    blocks usage:               0.01%
+================================
+Inode Information
+    inode number:               1
+    inode type:                 DIR
+    link count:                 2
+    inode size:                 128
+
+    DIR CONTENT
+       INODE: 00001, NAME: ..
+       INODE: 00001, NAME: .
+```
+
+## Options
+View tool-specific flags:
+```bash
+mkfs.numbfs --help
+fsck.numbfs --help
+```
+## Contributing
+Patches are welcome! Submit issues or PRs via GitHub.
+
+## License
+This project is licensed under the GNU General Public License v2.0 only (GPL-2.0-only).
+
+- See [LICENSE](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html) for full terms.
+
+- **Modifications** must be disclosed under the same license.

--- a/disk.h
+++ b/disk.h
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (C) 2025, Hongzhen Luo
+ */
+
+#ifndef __NUMBFS_DISK_H
+#define __NUMBFS_DISK_H
+
+#include "utils.h"
+#include <linux/types.h>
+
+#define NUMBFS_MAGIC    0x4E554D42 /* "NUMB" */
+
+/* the first block is reserved */
+#define NUMBFS_SUPER_OFFSET BYTES_PER_BLOCK
+
+#define NUMBFS_HOLE	(-32)
+
+/* root inode number */
+#define NUMBFS_ROOT_NID	1
+
+#define NUMBFS_NUM_DATA_ENTRY	10
+#define NUMBFS_MAX_PATH_LEN	62
+#define NUMBFS_MAX_ATTR 32
+
+/* 128-byte on-disk numbfs superblock, 64 bytes should be enough, but... */
+struct numbfs_super_block {
+	__le32 s_magic;
+	/* feature bits */
+	__le32 s_feature;
+	/* block addr of inode bitmap */
+	__le32 s_ibitmap_start;
+	/* block addr of inode zone */
+	__le32 s_inode_start;
+	/* block addr of block bitmap */
+	__le32 s_bbitmap_start;
+	/* block addr of data start */
+	__le32 s_data_start;
+	/* num of inodes*/
+	__le32 s_num_inodes;
+	/* num of free blocks*/
+	__le32 s_nfree_blocks;
+	/* reserved */
+	__u8 s_reserved[96];
+};
+
+/* 64-byte on-disk numbfs inode */
+struct numbfs_inode {
+	__le16 i_ino;
+	__le16 i_mode;
+	__le16 i_nlink;
+	__le16 i_uid;
+	__le16 i_gid;
+	__u8 reserved1[2]; /* padding */
+	__le32 i_size;
+	/* start block addr of xattrs */
+	__le32 i_xattr_start;
+	/* number of xattrs */
+	__u8 i_xattr_count;
+	__u8 reserved2[3]; /* padding */
+	/* block addr of data blocks */
+	__le32 i_data[10];
+};
+
+/* 64-byte on-disk numbfs dirent */
+struct numbfs_dirent {
+	char name[NUMBFS_MAX_PATH_LEN];
+	__le16 ino;
+};
+
+/* on-disk xattr entry */
+struct numbfs_xattr_entry {
+	__u8 e_valid;
+	__le16 e_name_len;
+	__le16 e_value_len;
+	__le16 e_start;
+};
+
+/* check the on-disk layout at compile time */
+static inline void numbfs_check_ondisk(void)
+{
+	NUMBFS_BUILD_BUG_ON(sizeof(struct numbfs_super_block) != 128);
+	NUMBFS_BUILD_BUG_ON(sizeof(struct numbfs_inode) != 64);
+	NUMBFS_BUILD_BUG_ON(sizeof(struct numbfs_dirent) != 64);
+}
+
+#endif

--- a/fsck.c
+++ b/fsck.c
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (C) 2025, Hongzhen Luo
+ */
+
+#include "internal.h"
+#include "disk.h"
+#include <getopt.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+
+static struct option long_options[] = {
+        {"help", no_argument, NULL, 'h'},
+        {"inodes", no_argument, NULL, 'i'},
+        {"blocks", no_argument, NULL, 'b'},
+        {"nid", required_argument, NULL, 'n'},
+        {0, 0, 0, 0}
+};
+
+struct numbfs_fsck_cfg {
+        bool show_inodes;
+        bool show_blocks;
+        int nid;
+        char *dev;
+};
+
+static void numbfs_fsck_help(void)
+{
+        printf(
+                "Usage: [OPTIONS] TARGET\n"
+                "Get disk statistics.\n"
+                "\n"
+                "Gerneral options:\n"
+                " --help                display this help information and exit\n"
+                " --inodes|-i           display inode usage\n"
+                " --blocks|-b           display block usage\n"
+                " --nid=X               display the inode information of inode@nid\n"
+        );
+}
+
+static void numbfs_fsck_parse_args(int argc, char **argv, struct numbfs_fsck_cfg *cfg)
+{
+        int opt;
+
+        while ((opt = getopt_long(argc, argv, "n:hib", long_options, NULL)) != -1) {
+                switch(opt) {
+                        case 'h':
+                                numbfs_fsck_help();
+                                exit(0);
+                        case 'i':
+                                cfg->show_inodes = true;
+                                break;
+                        case 'b':
+                                cfg->show_blocks = true;
+                                break;
+                        case 'n':
+                                cfg->nid = atoi(optarg);
+                                break;
+                        default:
+                                fprintf(stderr, "Unknown option: %s\n\n", argv[optind - 1]);
+                                numbfs_fsck_help();
+                                exit(1);
+                }
+        }
+
+        if (optind >= argc) {
+                fprintf(stderr, "missing block device!\n");
+                exit(1);
+        }
+
+        cfg->dev = strdup(argv[optind++]);
+        if (!cfg->dev) {
+                fprintf(stderr, "failed to get block device path\n");
+                exit(1);
+        }
+}
+
+static int count_bit(__u8 byte)
+{
+        int ret = 0, i;
+
+        for (i = 0; i < 8; i ++) {
+                ret += (byte & 1);
+                byte >>= 1;
+        }
+        return ret;
+}
+
+static int numbfs_fsck_used(char *buf)
+{
+        int i, ret = 0;
+
+        for (i = 0; i < BYTES_PER_BLOCK; i++)
+                ret += count_bit(buf[i]);
+        return ret;
+}
+
+/* show the inode information at @nid */
+static int numbfs_fsck_show_inode(struct numbfs_superblock_info *sbi,
+                                  int nid)
+{
+        struct numbfs_inode_info *inode_i;
+        struct numbfs_dirent *dir;
+        char buf[BYTES_PER_BLOCK];
+        int err, i;
+
+
+        inode_i = malloc(sizeof(*inode_i));
+        if (!inode_i)
+                return -ENOMEM;
+
+        inode_i->nid = nid;
+        inode_i->sbi = sbi;
+        err = numbfs_get_inode(sbi, inode_i);
+        if (err) {
+                fprintf(stderr, "error: failed to get inode information\n");
+                goto exit;
+        }
+
+        printf("================================\n");
+        printf("Inode Information\n");
+        printf("    inode number:               %d\n", nid);
+        if (S_ISDIR(inode_i->mode))
+                printf("    inode type:                 DIR\n");
+        else
+                printf("    inode type:                 REGULAR FILE\n");
+        printf("    link count:                 %d\n", inode_i->nlink);
+        printf("    inode size:                 %d\n\n", inode_i->size);
+
+        if (S_ISDIR(inode_i->mode)) {
+                printf("    DIR CONTENT\n");
+                for (i = 0; i < inode_i->size; i += sizeof(struct numbfs_dirent)) {
+                        if (i % BYTES_PER_BLOCK == 0) {
+                                err = numbfs_pread_inode(inode_i, buf, i / BYTES_PER_BLOCK);
+                                if (err) {
+                                        fprintf(stderr, "error: failed to read block@%d of inode@%d\n",
+                                                i / BYTES_PER_BLOCK, nid);
+                                        goto exit;
+                                }
+                        }
+                        dir = (struct numbfs_dirent*)&buf[i];
+                        printf("       INODE: %05d, NAME: %s\n", le16_to_cpu(dir->ino), dir->name);
+                }
+        }
+
+exit:
+        free(inode_i);
+        return err;
+}
+
+static int numbfs_fsck(int argc, char **argv)
+{
+        struct numbfs_fsck_cfg cfg = {
+                .show_inodes = 0,
+                .show_blocks = 0,
+                .nid = -1,
+                .dev = NULL
+        };
+        struct numbfs_superblock_info sbi;
+        char buf[BYTES_PER_BLOCK];
+        int fd, err, cnt, i;
+
+        numbfs_fsck_parse_args(argc, argv, &cfg);
+
+        fd = open(cfg.dev, O_RDWR, 0644);
+        if (fd < 0)
+                return -errno;
+
+        err = numbfs_get_superblock(&sbi, fd);
+        if (err) {
+                fprintf(stderr, "failed to read superblock\n");
+                goto exit;
+        }
+
+        printf("Superblock Information\n");
+        printf("    inode bitmap start:         %d\n", sbi.ibitmap_start);
+        printf("    inode zone start:           %d\n", sbi.inode_start);
+        printf("    block bitmap start:         %d\n", sbi.bbitmap_start);
+        printf("    data zone start:            %d\n", sbi.data_start);
+        printf("    total inodes:               %d\n", sbi.num_inodes);
+        printf("    total free data blocks:     %d\n", sbi.nfree_blocks);
+
+        if (cfg.show_inodes) {
+                cnt = 0;
+                for (i = sbi.ibitmap_start; i < sbi.inode_start; i++) {
+                        err = pread(fd, buf, BYTES_PER_BLOCK, i * BYTES_PER_BLOCK);
+                        if (err != BYTES_PER_BLOCK) {
+                                fprintf(stderr, "failed to read block@%d\n", i);
+                                err = -EIO;
+                                goto exit;
+                        }
+
+                        cnt += numbfs_fsck_used(buf);
+                }
+                printf("    inodes usage:               %.2f%%\n", 100.0 * cnt / sbi.num_inodes);
+        }
+
+        if (cfg.show_blocks) {
+                cnt = 0;
+                for (i = sbi.bbitmap_start; i < sbi.data_start; i++) {
+                        err = pread(fd, buf, BYTES_PER_BLOCK, i * BYTES_PER_BLOCK);
+                        if (err != BYTES_PER_BLOCK) {
+                                fprintf(stderr, "failed to read block@%d\n", i);
+                                err = -EIO;
+                                goto exit;
+                        }
+
+                        cnt += numbfs_fsck_used(buf);
+                }
+                printf("    blocks usage:               %.2f%%\n", 100.0 * cnt / sbi.nfree_blocks);
+        }
+
+        if (cfg.nid > 0) {
+                err = numbfs_fsck_show_inode(&sbi, cfg.nid);
+                if (err) {
+                        fprintf(stderr, "error: failed to show inode information\n");
+                        goto exit;
+                }
+        }
+
+        err = 0;
+exit:
+        close(fd);
+        free(cfg.dev);
+        return err;
+}
+
+int main(int argc, char **argv)
+{
+        int err;
+
+        err = numbfs_fsck(argc, argv);
+        if (err) {
+                fprintf(stderr, "Error occured in fsck, err: %d\n", err);
+                exit(1);
+        }
+        return 0;
+}

--- a/internal.h
+++ b/internal.h
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (C) 2025, Hongzhen Luo
+ */
+
+#ifndef __NUMBFS_INTERNAL_H
+#define __NUMBFS_INTERNAL_H
+
+#include "disk.h"
+#include <stdbool.h>
+
+struct numbfs_superblock_info {
+        int fd;
+        int feature;
+        int num_inodes;
+        int nfree_blocks;
+        int ibitmap_start;
+        int inode_start;
+        int bbitmap_start;
+        int data_start;
+
+        long long size;
+};
+
+/* TODO: xattr support */
+struct numbfs_inode_info {
+        /* in */
+        struct numbfs_superblock_info *sbi;
+        int nid;
+
+        /* out */
+        int mode;
+        int nlink;
+        int uid;
+        int gid;
+        int size;
+        int data[NUMBFS_NUM_DATA_ENTRY];
+};
+
+#define NUMBFS_BLOCKS_PER_BLOCK (BYTES_PER_BLOCK * BITS_PER_BYTE)
+#define NUMBFS_NODES_PER_BLOCK  (BYTES_PER_BLOCK / sizeof(struct numbfs_inode))
+
+/* calculate the block number of the bitmap related to @blkno */
+static inline int numbfs_bmap_blk(struct numbfs_superblock_info *sbi,
+                                  int blkno)
+{
+        return sbi->bbitmap_start + blkno / NUMBFS_BLOCKS_PER_BLOCK;
+}
+
+/* calculate the byte number in the block related to @blkno */
+static inline int numbfs_bmap_byte(int blkno)
+{
+        return  (blkno % NUMBFS_BLOCKS_PER_BLOCK) / BITS_PER_BYTE;
+}
+
+/* calculate the bit number in the byte related to @blkno */
+static inline int numbfs_bmap_bit(int blkno)
+{
+        return (blkno % NUMBFS_BLOCKS_PER_BLOCK) % BITS_PER_BYTE;
+}
+
+static inline int numbfs_inode_blk(struct numbfs_superblock_info *sbi,
+                                   int nid)
+{
+        return sbi->inode_start + nid / NUMBFS_NODES_PER_BLOCK;
+}
+
+/* read/write the blkno-th block in the device */
+int numbfs_read_block(struct numbfs_superblock_info *sbi,
+                      char buf[BYTES_PER_BLOCK], int blkno);
+int numbfs_write_block(struct numbfs_superblock_info *sbi,
+                       char buf[BYTES_PER_BLOCK], int blkno);
+
+/* read the on=disk superblock */
+int numbfs_get_superblock(struct numbfs_superblock_info *sbi, int fd);
+
+/* data block management */
+int numbfs_alloc_block(struct numbfs_superblock_info *sbi);
+int numbfs_free_block(struct numbfs_superblock_info *sbi, int blkno);
+
+/* get inode information according inode number*/
+int numbfs_get_inode(struct numbfs_superblock_info *sbi,
+                     struct numbfs_inode_info *inode_i);
+/* logical block number to physical block address translation */
+int numbfs_inode_blkaddr(struct numbfs_inode_info *inode_i,
+                         int pos, bool alloc, bool extent);
+
+/* read/write the logical block in inode's address space */
+int numbfs_pwrite_inode(struct numbfs_inode_info *inode_i,
+                        char buf[BYTES_PER_BLOCK], int blkaddr);
+int numbfs_pread_inode(struct numbfs_inode_info *inode_i,
+                       char buf[BYTES_PER_BLOCK], int blkaddr);
+
+/* make an empty dir */
+int numbfs_empty_dir(struct numbfs_superblock_info *sbi,
+                     int pnid, int nid);
+
+#endif

--- a/lib.c
+++ b/lib.c
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (C) 2025, Hongzhen Luo
+ */
+
+#include "internal.h"
+#include "utils.h"
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+int numbfs_read_block(struct numbfs_superblock_info *sbi,
+                      char buf[BYTES_PER_BLOCK], int blkno)
+{
+        int ret;
+
+        ret = pread(sbi->fd, buf, BYTES_PER_BLOCK, blkno * BYTES_PER_BLOCK);
+        if (ret != BYTES_PER_BLOCK) {
+                fprintf(stderr, "failed to read block@%d\n", blkno);
+                return -EIO;
+        }
+        return 0;
+}
+
+int numbfs_write_block(struct numbfs_superblock_info *sbi,
+                       char buf[BYTES_PER_BLOCK], int blkno)
+{
+        int ret;
+
+        ret = pwrite(sbi->fd, buf, BYTES_PER_BLOCK, blkno * BYTES_PER_BLOCK);
+        if (ret != BYTES_PER_BLOCK) {
+                fprintf(stderr, "failed to write block@%d\n", blkno);
+                return -EIO;
+        }
+        return 0;
+}
+
+/* get the superblock info from device@fd */
+int numbfs_get_superblock(struct numbfs_superblock_info *sbi, int fd)
+{
+        struct numbfs_super_block *sb;
+        char buf[BYTES_PER_BLOCK];
+        int err;
+
+        sbi->fd = fd;
+
+        err = numbfs_read_block(sbi, buf, NUMBFS_SUPER_OFFSET / BYTES_PER_BLOCK);
+        if (err)
+                return err;
+
+        sb = (struct numbfs_super_block*)buf;
+        if (le32_to_cpu(sb->s_magic) != NUMBFS_MAGIC) {
+                fprintf(stderr, "[corrupted] invalid superblock, magic: %X\n", le32_to_cpu(sb->s_magic));
+                return -EINVAL;
+        }
+
+        sbi->ibitmap_start      = le32_to_cpu(sb->s_ibitmap_start);
+        sbi->inode_start        = le32_to_cpu(sb->s_inode_start);
+        sbi->bbitmap_start      = le32_to_cpu(sb->s_bbitmap_start);
+        sbi->data_start         = le32_to_cpu(sb->s_data_start);
+        sbi->num_inodes         = le32_to_cpu(sb->s_num_inodes);
+        sbi->nfree_blocks       = le32_to_cpu(sb->s_nfree_blocks);
+        sbi->feature            = le32_to_cpu(sb->s_feature);
+        return 0;
+}
+
+/* alloc a free data block */
+int numbfs_alloc_block(struct numbfs_superblock_info *sbi)
+{
+        int ret, i, err, byte, bit;
+        char buf[BYTES_PER_BLOCK];
+
+        ret = -1;
+        for (i = 0; i < sbi->nfree_blocks; i++) {
+                /* read a new block */
+                if (i % NUMBFS_BLOCKS_PER_BLOCK == 0) {
+                        err = numbfs_read_block(sbi, buf, numbfs_bmap_blk(sbi, i));
+                        if (err)
+                                return err;
+                }
+
+                byte = numbfs_bmap_byte(i);
+                bit = numbfs_bmap_bit(i);
+                if (!(buf[byte] & (1 << bit))) {
+                        ret = i;
+                        /* set this bit to 1 */
+                        buf[byte] |= (1 << bit);
+                        err = numbfs_write_block(sbi, buf, numbfs_bmap_blk(sbi, i));
+                        if (err)
+                                return err;
+                        break;
+                }
+
+        }
+        return ret + sbi->data_start;
+}
+
+/* free a data block */
+int numbfs_free_block(struct numbfs_superblock_info *sbi, int blkno)
+{
+        char buf[BYTES_PER_BLOCK];
+        int err, byte, bit;
+
+        blkno -= sbi->data_start;
+        err = numbfs_read_block(sbi, buf, numbfs_bmap_blk(sbi, blkno));
+        if (err)
+                return err;
+
+        byte = numbfs_bmap_byte(blkno);
+        bit = numbfs_bmap_bit(blkno);
+        BUG_ON(!(buf[byte] & (1 << bit)));
+        buf[byte] &= ~(1 << bit);
+
+        err = numbfs_write_block(sbi, buf, numbfs_bmap_blk(sbi, blkno));
+        return err;
+}
+
+/* get the inode info at @inode_i->nid */
+int numbfs_get_inode(struct numbfs_superblock_info *sbi,
+                     struct numbfs_inode_info *inode_i)
+{
+        struct numbfs_inode *inode;
+        char buf[BYTES_PER_BLOCK];
+        int err, i;
+
+        err = numbfs_read_block(sbi, buf, numbfs_inode_blk(sbi, inode_i->nid));
+        if (err)
+                return err;
+
+        inode = ((struct numbfs_inode*)buf) + (inode_i->nid % NUMBFS_NODES_PER_BLOCK);
+        inode_i->sbi = sbi;
+        inode_i->mode   = le16_to_cpu(inode->i_mode);
+        inode_i->nlink  = le16_to_cpu(inode->i_nlink);
+        inode_i->uid    = le16_to_cpu(inode->i_uid);
+        inode_i->gid    = le16_to_cpu(inode->i_gid);
+        inode_i->size   = le32_to_cpu(inode->i_size);
+        for (i = 0; i < NUMBFS_NUM_DATA_ENTRY; i++)
+                inode_i->data[i] = le32_to_cpu(inode->i_data[i]);
+
+        return 0;
+}
+
+/*
+ * get the block that contains pos-th byte in the address space;
+ * if there is a hole, then alloc a block
+ */
+int numbfs_inode_blkaddr(struct numbfs_inode_info *inode, int pos, bool alloc, bool extent)
+{
+        int blkno;
+
+        if (extent) {
+                fprintf(stderr, "error: extent feature currently is not supported!\n");
+                return -ENOTSUP;
+        }
+
+        if ((pos / BYTES_PER_BLOCK) >= NUMBFS_NUM_DATA_ENTRY) {
+                fprintf(stderr, "error: pos@%d is out of range!\n", pos);
+                return -E2BIG;
+        }
+
+        if (alloc && inode->data[pos / BYTES_PER_BLOCK] == NUMBFS_HOLE) {
+                blkno = numbfs_alloc_block(inode->sbi);
+                if (blkno < 0) {
+                        fprintf(stderr, "failed to alloc data block\n");
+                        return blkno;
+                }
+                inode->data[pos / BYTES_PER_BLOCK] = blkno;
+        }
+
+        return inode->data[pos / BYTES_PER_BLOCK];
+}
+
+static int numbfs_dump_inode(struct numbfs_inode_info *inode_i)
+{
+        struct numbfs_superblock_info *sbi = inode_i->sbi;
+        struct numbfs_inode *inode;
+        char meta[BYTES_PER_BLOCK];
+        int nid = inode_i->nid;
+        int i, err;
+
+        err = numbfs_read_block(sbi, meta, numbfs_inode_blk(sbi, nid));
+        if (err)
+                return err;
+
+        inode = ((struct numbfs_inode*)meta) + (nid % NUMBFS_NODES_PER_BLOCK);
+        inode->i_ino    = cpu_to_le16(inode_i->nid);
+        inode->i_mode   = cpu_to_le16(inode_i->mode);
+        inode->i_nlink  = cpu_to_le16(inode_i->nlink);
+        inode->i_uid    = cpu_to_le16(inode_i->uid);
+        inode->i_gid    = cpu_to_le16(inode_i->gid);
+        inode->i_size   = cpu_to_le32(inode_i->size);
+        for (i = 0; i < NUMBFS_NUM_DATA_ENTRY; i++)
+                inode->i_data[i] = cpu_to_le32(inode_i->data[i]);
+
+        err = numbfs_write_block(sbi, meta, numbfs_inode_blk(sbi, nid));
+        if (err) {
+                fprintf(stderr, "error: failed to dump inode@%d\n", nid);
+                return -EIO;
+        }
+
+#ifdef HAVE_NUMBFS_DEBUG
+        err = numbfs_read_block(sbi, meta, numbfs_inode_blk(sbi, nid));
+        if (err) {
+                fprintf(stderr, "error: failed to read inode meta block@%d\n",
+                        numbfs_inode_blk(sbi, nid));
+                return -EIO;
+        }
+
+        inode = ((struct numbfs_inode*)meta) + (nid % NUMBFS_NODES_PER_BLOCK);
+        assert(inode->i_nlink == cpu_to_le16(inode_i->nlink));
+        assert(inode->i_size == cpu_to_le32(inode_i->size));
+        for (i = 0; i < NUMBFS_NUM_DATA_ENTRY; i++)
+                assert(inode->i_data[i] == cpu_to_le32(inode_i->data[i]));
+#endif
+
+        return 0;
+}
+
+/* write the buffer to the blkaddr-th block in the address space */
+int numbfs_pwrite_inode(struct numbfs_inode_info *inode_i,
+                        char buf[BYTES_PER_BLOCK], int blkaddr)
+{
+        int target, err;
+
+        /* extend the inode size with holes */
+        inode_i->size = max(inode_i->size, (blkaddr + 1) * BYTES_PER_BLOCK);
+
+        target = numbfs_inode_blkaddr(inode_i, blkaddr * BYTES_PER_BLOCK,
+                                      true, false);
+        if (target < 0)
+                return target;
+
+        err = numbfs_write_block(inode_i->sbi, buf, target);
+        if (err)
+                return err;
+
+        return numbfs_dump_inode(inode_i);
+}
+
+/* read the blkaddr-th block in the address space */
+int numbfs_pread_inode(struct numbfs_inode_info *inode_i,
+                       char buf[BYTES_PER_BLOCK], int blkaddr)
+{
+        int target;
+
+        target = numbfs_inode_blkaddr(inode_i, blkaddr * BYTES_PER_BLOCK,
+                                      false, false);
+        if (target < 0 && target != NUMBFS_HOLE)
+                return target;
+
+        /* read a hole */
+        if (round_up(inode_i->size, BYTES_PER_BLOCK) < blkaddr * BYTES_PER_BLOCK ||
+            target == NUMBFS_HOLE) {
+                memset(buf, 0, BYTES_PER_BLOCK);
+                return 0;
+        }
+
+        return numbfs_read_block(inode_i->sbi, buf, target);
+}
+
+/* make a empty dir */
+int numbfs_empty_dir(struct numbfs_superblock_info *sbi,
+                     int pnid, int nid)
+{
+        char buf[BYTES_PER_BLOCK];
+        struct numbfs_inode_info *inode_i;
+        struct numbfs_dirent *dir;
+        int err, i;
+
+        inode_i = malloc(sizeof(*inode_i));
+        if (!inode_i)
+                return -ENOMEM;
+
+        inode_i->nid = nid;
+        inode_i->sbi = sbi;
+        err = numbfs_get_inode(sbi, inode_i);
+        if (err)
+                goto exit;
+
+        /* sanity check */
+        for (i = 0; i < NUMBFS_NUM_DATA_ENTRY; i++)
+                BUG_ON(inode_i->data[i] != NUMBFS_HOLE);
+
+        /* write data block */
+        memset(buf, 0, BYTES_PER_BLOCK);
+        dir = (struct numbfs_dirent*)buf;
+        memcpy(dir->name, "..", 2);
+        dir->name[2] = '\0';
+        dir->ino = cpu_to_le16(pnid);
+        dir++;
+        memcpy(dir->name, ".", 1);
+        dir->name[1] = '\0';
+        dir->ino = cpu_to_le16(nid);
+        err = numbfs_pwrite_inode(inode_i, buf, 0);
+        if (err)
+                goto exit;
+
+        /* update metadata */
+        inode_i->mode = S_IFDIR;
+        inode_i->nlink = 2;
+        inode_i->uid = inode_i->gid = 0;
+        inode_i->size = sizeof(struct numbfs_dirent) * 2;
+        err = numbfs_dump_inode(inode_i);
+exit:
+        free(inode_i);
+        return err;
+}

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,20 @@
+project('numbfs-utils',
+        'c',
+        version: '0.1',
+        default_options: ['warning_level=3'])
+
+#
+# Feature detection, such as print debug info, etc.
+#
+private_cfg = configuration_data()
+
+if get_option('numbfs_debug')
+        private_cfg.set('HAVE_NUMBFS_DEBUG', '1')
+endif
+
+#
+# write private flags to numbfs_config.h
+#
+configure_file(output: 'numbfs_config.h', configuration : private_cfg)
+
+executable('mkfs.numbfs', ['mkfs.c', 'lib.c'], install: true)

--- a/meson.build
+++ b/meson.build
@@ -18,3 +18,4 @@ endif
 configure_file(output: 'numbfs_config.h', configuration : private_cfg)
 
 executable('mkfs.numbfs', ['mkfs.c', 'lib.c'], install: true)
+executable('fsck.numbfs', ['fsck.c', 'lib.c'], install: true)

--- a/meson.build
+++ b/meson.build
@@ -19,3 +19,6 @@ configure_file(output: 'numbfs_config.h', configuration : private_cfg)
 
 executable('mkfs.numbfs', ['mkfs.c', 'lib.c'], install: true)
 executable('fsck.numbfs', ['fsck.c', 'lib.c'], install: true)
+
+numbfs_test = executable('numbfs_unit_test', ['test.c', 'lib.c'])
+test('numbfs_test', numbfs_test)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('numbfs_debug', type : 'boolean', value : false,
+       description: 'Enable numbfs debug info')

--- a/mkfs.c
+++ b/mkfs.c
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (C) 2025, Hongzhen Luo
+ */
+
+#include "internal.h"
+#include "numbfs_config.h"
+#include "disk.h"
+#include <getopt.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <linux/fs.h>
+
+#define NUMBFS_DEFAULT_INODES 4096
+
+static struct numbfs_superblock_info sbi;
+
+static struct option log_options[] = {
+        {"help", no_argument, NULL, 'h'},
+        {"num_inodes", required_argument, NULL, 2},
+        {"size", required_argument, NULL, 's'},
+        {0, 0, 0, 0}
+};
+
+static void numbfs_help_info(void)
+{
+        printf(
+                "Usage: [OPTIONS] TARGET\n"
+                "Create a NumbFS filesystem image.\n"
+                "\n"
+                "Gerneral options:\n"
+                " --help                display this help information and exit\n"
+                " --num_inodes=#        specify the number of inodes (default: 4096)\n"
+                " --size=#{M,K,G}       spacify the filesystem image size\n"
+        );
+}
+
+#ifdef HAVE_NUMBFS_DEBUG
+static void numbfs_show_config(void)
+{
+        printf(
+                "All configs:\n"
+                "    num_inodes: %d\n", sbi.num_inodes
+        );
+}
+#endif
+
+static int numbfs_open_dev(char *dev)
+{
+        int fd, ret;
+        struct stat st;
+
+        fd = open(dev, O_RDWR | O_CREAT, 0644);
+        if (fd < 0)
+                return -errno;
+
+        ret = fstat(fd, &st);
+        if (ret) {
+                fprintf(stderr, "fail to fstat %s\n", dev);
+                close(fd);
+                return -errno;
+        }
+
+        sbi.fd = fd;
+        return 0;
+}
+
+static int numbfs_parse_args(int argc, char **argv)
+{
+        int opt, val, ret;
+        char *img_path, unit;
+        long long size;
+
+        while ((opt = getopt_long(argc, argv, "s:h", log_options, NULL)) != -1) {
+                switch(opt) {
+                        case 'h':
+                                numbfs_help_info();
+                                exit(0);
+                        case 2:
+                                val = atoi(optarg);
+                                if (val <= 0 || val & 0x7) {
+                                        fprintf(stderr, "Error: invalid num_inodes: %d, should be positive and multiple of 8\n", val);
+                                        return -EINVAL;
+                                }
+                                sbi.num_inodes = val;
+                                break;
+                        case 's':
+                                if (sscanf(optarg, "%lld%c", &size, &unit) < 1)  {
+                                        fprintf(stderr, "invalid size format: %s ,should be xxx K, xxx M, xxx G\n", optarg);
+                                        exit(1);
+                                }
+                                if (unit == 'k' || unit == 'K')
+                                        sbi.size = size * 1024LL;
+                                else if (unit == 'm' || unit == 'M')
+                                        sbi.size = size * 1024LL * 1024LL;
+                                else if (unit == 'g' || unit == 'G')
+                                        sbi.size = size * 1024LL * 1024LL * 1024LL;
+                                else
+                                        sbi.size = size;
+                                break;
+                        default:
+                                fprintf(stderr, "Unknown option: %s\n\n", argv[optind - 1]);
+                                numbfs_help_info();
+                                exit(1);
+                }
+        }
+
+        if (optind >= argc) {
+                fprintf(stderr, "miss block device path!\n");
+                exit(1);
+        }
+
+        img_path = strdup(argv[optind++]);
+        if (!img_path) {
+                fprintf(stderr, "failed to get block device path\n");
+                return -ENOMEM;
+        }
+
+        ret = numbfs_open_dev(img_path);
+        free(img_path);
+        return ret;
+}
+
+static void numbfs_init_config(void)
+{
+        sbi.fd = -1;
+        sbi.num_inodes = NUMBFS_DEFAULT_INODES;
+        sbi.size = -1;
+}
+
+/*
+ * The disk layout:
+ * | reserved | superblock | inode bitmap | inodes | block bitmap | data |
+ */
+static int numbfs_mkfs(void)
+{
+        int i, err, total_blocks, remain;
+        struct numbfs_super_block *sb;
+        char buf[BYTES_PER_BLOCK];
+        off_t start, end;
+        struct stat st;
+        long long dev_size;
+
+        err = fstat(sbi.fd, &st);
+        if (err) {
+                fprintf(stderr, "fail to fstat block dev\n");
+                return -errno;
+        }
+
+        /* get the block device size */
+        if (S_ISBLK(st.st_mode)) {
+                if (ioctl(sbi.fd, BLKGETSIZE64, &dev_size) == -1) {
+                        perror("fail to get block device's size\n");
+                        close(sbi.fd);
+                        return -EINVAL;
+                }
+        } else {
+                dev_size = st.st_size;
+        }
+
+
+        if (sbi.size == -1) {
+                sbi.size = dev_size;
+        } else {
+                if (dev_size < sbi.size) {
+                        fprintf(stderr, "error: the device size (%lld) is smaller than required size (%lld)\n",
+                                        dev_size,
+                                        sbi.size);
+                        return -EINVAL;
+                } else if (dev_size > sbi.size) {
+                        fprintf(stderr, "warning: the device size (%lld) is larger than required size (%lld), truncate it\n",
+                                        dev_size,
+                                        sbi.size);
+                }
+        }
+
+        if (sbi.size <=  2 * BYTES_PER_BLOCK + round_up(sbi.num_inodes * 64, BYTES_PER_BLOCK) + 3) {
+                fprintf(stderr, "device too small, should be at least %d Bytes\n",
+                                2 * BYTES_PER_BLOCK + round_up(sbi.num_inodes * 64, BYTES_PER_BLOCK) + 3);
+                close(sbi.fd);
+                return -EINVAL;
+        }
+
+        total_blocks = sbi.size / BYTES_PER_BLOCK;
+
+        /* inode bitmap start block addr */
+        sbi.ibitmap_start = 2;
+        /* inodes start block add */
+        sbi.inode_start = sbi.ibitmap_start +
+                        DIV_ROUND_UP(DIV_ROUND_UP(sbi.num_inodes, BITS_PER_BYTE), BYTES_PER_BLOCK);
+        /* block bitmap start block addr */
+        sbi.bbitmap_start = sbi.inode_start +
+                        DIV_ROUND_UP(sbi.num_inodes * sizeof(struct numbfs_inode), BYTES_PER_BLOCK);
+
+        remain = total_blocks - sbi.bbitmap_start - 1;
+        /* nr free data blocks */
+        sbi.nfree_blocks = remain -
+                        DIV_ROUND_UP(DIV_ROUND_UP(remain, BITS_PER_BYTE), BYTES_PER_BLOCK);
+
+        start = 2;
+        end = sbi.bbitmap_start +
+                        DIV_ROUND_UP(DIV_ROUND_UP(sbi.nfree_blocks, BITS_PER_BYTE), BYTES_PER_BLOCK);
+        memset(buf, 0, sizeof(buf));
+        /* clear all the bits in range [start, end] */
+        for (i = start; i < end; i++) {
+                err = pwrite(sbi.fd, buf, BYTES_PER_BLOCK, i * BYTES_PER_BLOCK);
+                if (err != BYTES_PER_BLOCK) {
+                        fprintf(stderr, "failed to write to block@[%d, %d]\n", i, i + 1);
+                        return -EIO;
+                }
+        }
+
+        /* set all the data array to NUMBFS_HOLE */
+        for (i = sbi.inode_start; i < sbi.bbitmap_start; i++) {
+                int j, k;
+                struct numbfs_inode *inode;
+
+                err = numbfs_read_block(&sbi, buf, i);
+                if (err)
+                        return err;
+
+                for (j = 0; j < (int)NUMBFS_NODES_PER_BLOCK; j++) {
+                        inode = ((struct numbfs_inode*)buf) + j;
+                        for (k = 0; k < NUMBFS_NUM_DATA_ENTRY; k++)
+                                inode->i_data[k] = cpu_to_le32(NUMBFS_HOLE);
+                }
+
+                err = numbfs_write_block(&sbi, buf, i);
+                if (err)
+                        return err;
+        }
+
+        /* data zone start block addr */
+        sbi.data_start = end;
+
+#ifdef HAVE_NUMBFS_DEBUG
+        printf("Superblock information:\n");
+        printf("    num_inodes: %d\n", sbi.num_inodes);
+        printf("    ibitmap_start: %d\n", sbi.ibitmap_start);
+        printf("    inodes_start: %d\n", sbi.inode_start);
+        printf("    bbitmap_start: %d\n", sbi.bbitmap_start);
+        printf("    num_free_blocks: %d\n", sbi.nfree_blocks);
+#endif
+
+        /* create the root inode */
+        err = numbfs_empty_dir(&sbi, NUMBFS_ROOT_NID, NUMBFS_ROOT_NID);
+        if (err) {
+                fprintf(stderr, "failed to prepare root inode, err: %d\n", err);
+                return err;
+        }
+
+        memset(buf, 0, BYTES_PER_BLOCK);
+        sb = (struct numbfs_super_block*)buf;
+        sb->s_magic = NUMBFS_MAGIC;
+        sb->s_feature = cpu_to_le32(0);
+        sb->s_ibitmap_start = cpu_to_le32(sbi.ibitmap_start);
+        sb->s_inode_start = cpu_to_le32(sbi.inode_start);
+        sb->s_bbitmap_start = cpu_to_le32(sbi.bbitmap_start);
+        sb->s_data_start = cpu_to_le32(sbi.data_start);
+        sb->s_num_inodes = cpu_to_le32(sbi.num_inodes);
+        sb->s_nfree_blocks = cpu_to_le32(sbi.nfree_blocks);
+
+        return numbfs_write_block(&sbi, buf, NUMBFS_SUPER_OFFSET / BYTES_PER_BLOCK);
+}
+
+static void numbfs_cleanup(void)
+{
+        if (sbi.fd >= 0)
+                close(sbi.fd);
+}
+
+int main(int argc, char **argv)
+{
+        int err;
+
+        numbfs_init_config();
+
+        err = numbfs_parse_args(argc, argv);
+        if (err) {
+                fprintf(stderr, "Error occurred while parsing arguments.\n");
+                goto exit;
+        }
+
+#ifdef HAVE_NUMBFS_DEBUG
+        numbfs_show_config();
+#endif
+
+        err = numbfs_mkfs();
+        if (err)
+                fprintf(stderr, "Error: failed to mkfs\n");
+
+exit:
+        numbfs_cleanup();
+        return 0;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Packages required for building numbfs image,
+# Build packages:
+meson
+ninja

--- a/test.c
+++ b/test.c
@@ -1,0 +1,165 @@
+#include "internal.h"
+#include "disk.h"
+#include "utils.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+
+#define FILE_SIZE (10 * 1024 * 1024) // 10MB
+#define TEST_NUM_INODES 1024
+
+struct numbfs_superblock_info sbi;
+
+static void init_sbi(int fd)
+{
+        int err, total_blocks, remain;
+        char buf[BYTES_PER_BLOCK];
+        off_t start, end;
+        int i;
+
+        sbi.fd = fd;
+        sbi.size = FILE_SIZE;
+
+        total_blocks = sbi.size / BYTES_PER_BLOCK;
+
+        sbi.num_inodes = TEST_NUM_INODES;
+
+        /* inode bitmap start block addr */
+        sbi.ibitmap_start = 2;
+        /* inodes start block add */
+        sbi.inode_start = sbi.ibitmap_start +
+                        DIV_ROUND_UP(DIV_ROUND_UP(sbi.num_inodes, BITS_PER_BYTE), BYTES_PER_BLOCK);
+        /* block bitmap start block addr */
+        sbi.bbitmap_start = sbi.inode_start +
+                        DIV_ROUND_UP(sbi.num_inodes * sizeof(struct numbfs_inode), BYTES_PER_BLOCK);
+
+        remain = total_blocks - sbi.bbitmap_start - 1;
+        /* nr free data blocks */
+        sbi.nfree_blocks = remain -
+                        DIV_ROUND_UP(DIV_ROUND_UP(remain, BITS_PER_BYTE), BYTES_PER_BLOCK);
+
+        start = 2;
+        end = sbi.bbitmap_start +
+                        DIV_ROUND_UP(DIV_ROUND_UP(sbi.nfree_blocks, BITS_PER_BYTE), BYTES_PER_BLOCK);
+        memset(buf, 0, sizeof(buf));
+        /* clear all the bits in range [start, end] */
+        for (i = start; i < end; i++) {
+                err = pwrite(sbi.fd, buf, BYTES_PER_BLOCK, i * BYTES_PER_BLOCK);
+                assert(err == BYTES_PER_BLOCK);
+        }
+        sbi.data_start = end;
+
+        /* set all the data array to NUMBFS_HOLE */
+        for (i = sbi.inode_start; i < sbi.bbitmap_start; i++) {
+                int j, k;
+                struct numbfs_inode *inode;
+
+                assert(!numbfs_read_block(&sbi, buf, i));
+
+                for (j = 0; j < (int)NUMBFS_NODES_PER_BLOCK; j++) {
+                        inode = ((struct numbfs_inode*)buf) + j;
+                        for (k = 0; k < NUMBFS_NUM_DATA_ENTRY; k++)
+                                inode->i_data[k] = cpu_to_le32(NUMBFS_HOLE);
+                }
+
+                assert(!numbfs_write_block(&sbi, buf, i));
+        }
+
+        /* data zone start block addr */
+}
+
+static void test_hole(void)
+{
+        struct numbfs_inode_info inode_i;
+        char wcontent[BYTES_PER_BLOCK];
+        char rcontent[BYTES_PER_BLOCK];
+        char zero[BYTES_PER_BLOCK];
+        int i;
+
+#define TEST_NID        1
+#define TEST_BLK        7
+
+
+        /* random content to write */
+        for (i = 0; i < BYTES_PER_BLOCK; i ++)
+                wcontent[i] = i % 10;
+        memset(zero, 0, BYTES_PER_BLOCK);
+
+        /* get inode info */
+        inode_i.sbi = &sbi;
+        inode_i.nid = TEST_NID;
+
+        assert(!numbfs_get_inode(&sbi, &inode_i));
+
+        assert(!numbfs_pwrite_inode(&inode_i, wcontent, TEST_BLK));
+        for (i = 0; i < TEST_BLK; i++) {
+                assert(!numbfs_pread_inode(&inode_i, rcontent, i));
+                /* should be zero, since these blocks are all holes */
+                assert(!memcmp(rcontent, zero, BYTES_PER_BLOCK));
+        }
+
+        assert(!numbfs_pread_inode(&inode_i, rcontent, TEST_BLK));
+        assert(!memcmp(rcontent, wcontent, BYTES_PER_BLOCK));
+
+        /* write the middle block */
+        assert(!numbfs_pwrite_inode(&inode_i, wcontent, TEST_BLK / 2));
+        assert(!numbfs_pread_inode(&inode_i, rcontent, TEST_BLK / 2));
+        assert(!memcmp(wcontent, rcontent, BYTES_PER_BLOCK));
+
+#undef TEST_NID
+#undef TEST_BLK
+}
+
+static int numbfs_block_count(void)
+{
+        int cnt = 0, i, byte, bit;
+        char buf[BYTES_PER_BLOCK];
+
+        for (i = 0; i < sbi.nfree_blocks; i++) {
+                if (i % NUMBFS_BLOCKS_PER_BLOCK == 0)
+                        assert(!numbfs_read_block(&sbi, buf, numbfs_bmap_blk(&sbi, i)));
+                byte = numbfs_bmap_byte(i);
+                bit = numbfs_bmap_bit(i);
+                if (!(buf[byte] & (1 << bit)))
+                        cnt++;
+        }
+        return cnt;
+}
+
+static void test_block_management(void)
+{
+#define TEST_TIMES (BYTES_PER_BLOCK * 2 + 1)
+        int total_blocks = numbfs_block_count();
+        int blks[TEST_TIMES];
+        int i;
+
+        for (i = 0; i < TEST_TIMES; i++) {
+                blks[i] = numbfs_alloc_block(&sbi);
+                assert(total_blocks - numbfs_block_count() == i + 1);
+        }
+
+        for (int i = 0; i < TEST_TIMES; i++) {
+                assert(!numbfs_free_block(&sbi, blks[i]));
+                assert(total_blocks - numbfs_block_count() == TEST_TIMES - i - 1);
+        }
+}
+
+int main() {
+        const char *filename = "./numbfs_test_file_xxx";
+        int fd = open(filename, O_RDWR | O_CREAT, 0644);
+
+        assert(fd != -1);
+        assert(ftruncate(fd, FILE_SIZE) != -1);
+
+        init_sbi(fd);
+
+        /* do tests */
+        test_hole();
+        test_block_management();
+
+        close(fd);
+        assert(remove(filename) == 0);
+        return 0;
+}

--- a/utils.h
+++ b/utils.h
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (C) 2025, Hongzhen Luo
+ */
+
+#ifndef __NUMBFS_UTILS_H
+#define __NUMBFS_UTILS_H
+
+#include <assert.h>
+
+#define NUMBFS_BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2 * !!(condition)]))
+#define BUG_ON(cond)        assert(!(cond))
+
+#define BITS_PER_BYTE       8
+#define BYTES_PER_BLOCK     512
+
+#define __round_mask(x, y)      ((__typeof__(x))((y)-1))
+#define round_up(x, y)          ((((x)-1) | __round_mask(x, y))+1)
+#define round_down(x, y)        ((x) & ~__round_mask(x, y))
+
+#ifndef max
+#define max(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
+#ifndef min
+#define min(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+#define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+/*
+ * The host byte order is the same as network byte order,
+ * so these functions are all just identity.
+ */
+#define cpu_to_le16(x) ((__u16)(x))
+#define cpu_to_le32(x) ((__u32)(x))
+#define cpu_to_le64(x) ((__u64)(x))
+#define le16_to_cpu(x) ((__u16)(x))
+#define le32_to_cpu(x) ((__u32)(x))
+#define le64_to_cpu(x) ((__u64)(x))
+
+#else
+#if __BYTE_ORDER == __BIG_ENDIAN
+#define cpu_to_le16(x) (__builtin_bswap16(x))
+#define cpu_to_le32(x) (__builtin_bswap32(x))
+#define cpu_to_le64(x) (__builtin_bswap64(x))
+#define le16_to_cpu(x) (__builtin_bswap16(x))
+#define le32_to_cpu(x) (__builtin_bswap32(x))
+#define le64_to_cpu(x) (__builtin_bswap64(x))
+#else
+#pragma error
+#endif
+#endif
+
+#endif


### PR DESCRIPTION
This pull request introduces a complete suite of user-space utilities for the NumbFS filesystem. It implements core functionality including on-disk structure management, block allocation, and inode operations. The implementation includes `mkfs.numbfs` for filesystem creation and `fsck.numbfs` for inspection/verification, with initial unit test coverage. The project features Meson build system integration and comprehensive documentation with installation guides and usage examples. Basic functionality has been verified through preliminary testing.