### PR TITLE
numbfs-utils: enhance fsck with link file information display and improved inode allocation tests

### DIFF
--- a/fsck.c
+++ b/fsck.c
@@ -101,6 +101,11 @@ static int numbfs_fsck_used(char *buf)
         return ret;
 }
 
+static inline char *numbfs_dir_type(int type)
+{
+        return type == DT_DIR ? "DIR    " : "REGULAR";
+}
+
 /* show the inode information at @nid */
 static int numbfs_fsck_show_inode(struct numbfs_superblock_info *sbi,
                                   int nid)
@@ -147,7 +152,8 @@ static int numbfs_fsck_show_inode(struct numbfs_superblock_info *sbi,
                                 }
                         }
                         dir = (struct numbfs_dirent*)&buf[i];
-                        printf("       INODE: %05d, NAMELEN: %02d NAME: %s\n", le16_to_cpu(dir->ino), dir->name_len, dir->name);
+                        printf("       INODE: %05d, TYPE: %s, NAMELEN: %02d NAME: %s\n",
+                                le16_to_cpu(dir->ino), numbfs_dir_type(dir->type),dir->name_len, dir->name);
                 }
         }
 

--- a/fsck.c
+++ b/fsck.c
@@ -103,7 +103,12 @@ static int numbfs_fsck_used(char *buf)
 
 static inline char *numbfs_dir_type(int type)
 {
-        return type == DT_DIR ? "DIR    " : "REGULAR";
+        if (type == DT_DIR)
+                return "DIR    ";
+        else if (type == DT_LNK)
+                return "SYMLINK";
+        else
+                return "REGULAR";
 }
 
 /* show the inode information at @nid */
@@ -133,6 +138,8 @@ static int numbfs_fsck_show_inode(struct numbfs_superblock_info *sbi,
         printf("    inode number:               %d\n", nid);
         if (S_ISDIR(inode_i->mode))
                 printf("    inode type:                 DIR\n");
+        else if (S_ISLNK(inode_i->mode))
+                printf("    inode type:                 SYMLINK\n");
         else
                 printf("    inode type:                 REGULAR FILE\n");
         printf("    link count:                 %d\n", inode_i->nlink);

--- a/test.c
+++ b/test.c
@@ -206,6 +206,7 @@ static void test_inode_management(void)
                 int free_inodes;
 
                 assert(!numbfs_alloc_inode(&sbi, &inodes[i]));
+                assert(inodes[i] == i);
                 free_inodes = numbfs_inode_count();
                 assert(total_inodes - i - 1 == free_inodes);
                 assert(sbi.free_inodes == free_inodes);


### PR DESCRIPTION
This PR introduces enhancements to the numbfs-utils fsck tool, adding support for displaying link file information and improving test coverage for inode allocation.