### PR TITLE
numbfs: add extended attribute (xattr) support

### DIFF
--- a/disk.h
+++ b/disk.h
@@ -81,13 +81,26 @@ struct numbfs_timestamps {
 	__u8 reserved[8];
 };
 
+/* xattr name indexes */
+#define NUMBFS_XATTR_INDEX_USER              1
+#define NUMBFS_XATTR_INDEX_TRUSTED           2
+
+#define NUMBFS_XATTR_MAXNAME	16
+#define NUMBFS_XATTR_MAXVALUE	32
+
 /* on-disk xattr entry */
 struct numbfs_xattr_entry {
 	__u8 e_valid;
-	__le16 e_name_len;
-	__le16 e_value_len;
-	__le16 e_start;
+	__u8 e_type;
+	__u8 e_nlen;
+	__u8 e_vlen;
+	__u8 e_name[NUMBFS_XATTR_MAXNAME];
+	__u8 e_value[NUMBFS_XATTR_MAXVALUE];
 };
+
+#define NUMBFS_XATTR_MAX_ENTRY \
+	((BYTES_PER_BLOCK - sizeof(struct numbfs_timestamps)) / sizeof(struct numbfs_xattr_entry))
+#define NUMBFS_XATTR_ENTRY_START	(sizeof(struct numbfs_timestamps))
 
 /* check the on-disk layout at compile time */
 static inline void numbfs_check_ondisk(void)

--- a/internal.h
+++ b/internal.h
@@ -38,6 +38,7 @@ struct numbfs_inode_info {
         int size;
         int data[NUMBFS_NUM_DATA_ENTRY];
         int xattr_start;
+        int xattr_count;
 };
 
 #define NUMBFS_BLOCKS_PER_BLOCK (BYTES_PER_BLOCK * BITS_PER_BYTE)

--- a/lib.c
+++ b/lib.c
@@ -168,6 +168,7 @@ int numbfs_get_inode(struct numbfs_superblock_info *sbi,
         for (i = 0; i < NUMBFS_NUM_DATA_ENTRY; i++)
                 ni->data[i] = le32_to_cpu(inode->i_data[i]);
         ni->xattr_start = le32_to_cpu(inode->i_xattr_start);
+        ni->xattr_count = inode->i_xattr_count;
 
         return 0;
 }
@@ -385,6 +386,7 @@ int numbfs_empty_dir(struct numbfs_superblock_info *sbi, int pnid)
         if (err)
                 return err;
 
+        memset(&inode, 0, sizeof(struct numbfs_inode_info));
         inode.nid = nid;
         inode.sbi = sbi;
         inode.mode = S_IFDIR | 0755;


### PR DESCRIPTION
This commit implements the core infrastructure for extended attributes (xattr) in the numbfs filesystem.